### PR TITLE
GitHub action

### DIFF
--- a/materials/script.qmd
+++ b/materials/script.qmd
@@ -507,7 +507,7 @@ install()
 ## Continuous Integration
 
 ```{r}
-use_github_actions()
+use_github_action()
 ```
 
 **commit and push**

--- a/pkg-dev-psc.Rproj
+++ b/pkg-dev-psc.Rproj
@@ -18,4 +18,3 @@ PackageInstallArgs: --no-multiarch --with-keep.source
 
 MarkdownWrap: Sentence
 MarkdownReferences: Document
-MarkdownCanonical: Yes


### PR DESCRIPTION
use_github_actions() is deprecated; use use_github_action() instead. It brings up a menu to choose which, if run with no arguments. I also changed it on slide 126